### PR TITLE
Added functions to help with conversions.

### DIFF
--- a/src/none_prec_common.rs
+++ b/src/none_prec_common.rs
@@ -18,6 +18,13 @@ macro_rules! define_none_prec_common {
         /// The largest powers of 10.
         pub const MAX_POWERS: Self = Self(I::MAX_POWERS);
 
+        /// Returns the inner integer.
+        /// 
+        /// Can be used to write conversions to and from fixed-point types of other crates.
+        pub const fn mantissa(&self) -> I {
+            self.0
+        }
+
         /// Computes the absolute value of self.
         /// 
         /// # Overflow behavior

--- a/src/static_prec_fpdec.rs
+++ b/src/static_prec_fpdec.rs
@@ -21,6 +21,18 @@ pub struct StaticPrecFpdec<I, const P: i32>(pub(crate) I);
 impl<I, const P: i32> StaticPrecFpdec<I, P>
 where I: FpdecInner
 {
+    /// Create a new instance with the specified mantissa and the type's precision.
+    pub const fn new(mantissa: I) -> Self {
+        Self(mantissa)
+    }
+
+    /// Returns the constant value of type parameter `P`.
+    /// 
+    /// Can be used with [`Self::mantissa()`] for conversions to avoid repeating yourself.
+    pub const fn precision(&self) -> i32 {
+        P
+    }
+
     crate::none_prec_common::define_none_prec_common!();
 
     /// Checked multiplication. Computes `self * rhs`, returning `None` if


### PR DESCRIPTION
In my app, I'm also using the [`rust_decimal`](https://crates.io/crates/rust_decimal) crate. I'm using your crate for a specific part of the algorithm which is required to operate with exactly 10 decimal places. This means I need conversions in both directions between `rust_decimal::Decimal` and `primitive_fixed_point_decimal::StaticPrecFpdec`. These new functions make that possible.

Note that I didn't add a constructor for `OobPrecFpdec`, because my app doesn't need that type and I'm unsure about its use cases.