### PR TITLE
Fixes Bug in checked_div_ext

### DIFF
--- a/src/fpdec_inner.rs
+++ b/src/fpdec_inner.rs
@@ -74,7 +74,7 @@ pub trait FpdecInner: Sized + PrimSignedInt {
             let exp = Self::get_exp(-diff_scale as usize)?;
             self.calc_mul_div(exp, rhs, rounding, cum_error)
         } else {
-            self.checked_mul(&rhs)
+            self.checked_div(&rhs)
         }
     }
 


### PR DESCRIPTION
Fixes bug causing incorrect return values from `checked_div_ext` when `diff_scale == 0`.

```rust
// MWE

use primitive_fixed_point_decimal::fpdec;
use primitive_fixed_point_decimal::ConstScaleFpdec;
use primitive_fixed_point_decimal::Rounding;

fn main() {
    let a: ConstScaleFpdec<i32, 4> = fpdec!(12.);
    let b: ConstScaleFpdec<i32, 1> = fpdec!(4.);
    let c: ConstScaleFpdec<i32, 3> = a.checked_div(b).unwrap(); // diff_scale == 4 - 1 - 3
    println!("{} / {} = {}", a, b, c); // before: 4800, now: 3
}
```