### PR TITLE
Add the `no-std::no-alloc` category into Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/WuBingzheng/primitive_fixed_point_decimal"
 documentation = "https://docs.rs/primitive_fixed_point_decimal"
 keywords = ["fixed-point", "decimal"]
-categories = ["data-structures", "finance", "mathematics"]
+categories = ["data-structures", "finance", "mathematics", "no-std", "no-std::no-alloc"]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This crate is the only fixed-point decimal crate I've found so far that doesn't pull in `alloc`. Thank you for that! :D

I've added the `no-std::no-alloc` category in `Cargo.toml`, making the crate easier to find on Crates.io for embedded purposes.

## Testing

I did a `cargo publish --dry-run --allow-dirty` to ensure the category is valid. Then, I tried compiling with only `core`, which worked great!

<img width="870" height="314" alt="screenshot of a cargo-build command, without the std/alloc libraries, being ran successfully" src="https://github.com/user-attachments/assets/ff415d87-7dba-4b4d-bd81-7a093a96a809" />

## License

This contribution was written by me. It is licensed under the MIT license, just like the rest of the repository.